### PR TITLE
Set Nextcloud to be the root ingress

### DIFF
--- a/edgemess/templates/ingress.yaml
+++ b/edgemess/templates/ingress.yaml
@@ -7,18 +7,17 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http: 
-      paths:
-      - path: /nextcloud(/|$)(.*)
-        pathType: Prefix
-        backend:
-          service:
-            name: mess-nextcloud-service
-            port:
-              number: 80
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mess-nextcloud-service
+                port:
+                  number: 80
 
 ---
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,12 +27,12 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - http: 
-      paths:
-      - path: /keycloak
-        pathType: Prefix
-        backend:
-          service:
-            name: mess-keycloak-service
-            port:
-              number: 8080
+    - http:
+        paths:
+          - path: /keycloak
+            pathType: Prefix
+            backend:
+              service:
+                name: mess-keycloak-service
+                port:
+                  number: 8080


### PR DESCRIPTION
I mean this fixes some issues where the nextcloud CSS files are 404. I was able to navigate into keycloak even though Nextcloud is as root. I guess this is due to the two ingresses?